### PR TITLE
Make an OSGi bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,12 @@
             <version>5.7.0</version>
             <scope>test</scope>
         </dependency>
-        
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.annotation</artifactId>
+            <version>7.0.0</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -132,21 +137,25 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <version>5.3.0</version>
                 <executions>
                     <execution>
-                        <id>jigawatt</id>
-                        <phase>package</phase>
                         <goals>
-                            <goal>shade</goal>
+                            <goal>bnd-process</goal>
                         </goals>
-                        <configuration>
-                            <finalName>jigawatt</finalName>
-                        </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
             </plugin>
 	    <plugin>
 	      <artifactId>maven-clean-plugin</artifactId>

--- a/src/main/java/org/openjdk/jigawatts/Jigawatts.java
+++ b/src/main/java/org/openjdk/jigawatts/Jigawatts.java
@@ -40,6 +40,9 @@ package org.openjdk.jigawatts;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import org.osgi.annotation.bundle.Header;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -51,6 +54,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collections;
 
+@Header(name = "Bundle-NativeCode", value = "libJigawatts.so; osname = Linux")
 public class Jigawatts {
 
     private static final Jigawatts crContext;
@@ -170,17 +174,21 @@ public class Jigawatts {
 
     static {
 
-        String libDir = System.getProperty("java.io.tmpdir");
-        String tmpLib = libDir+ "/" + System.mapLibraryName("Jigawatts");
-        
-        if (!Files.exists(Paths.get(tmpLib))) {
-            try {
-                copyLibrary("Jigawatts", libDir);
-            } catch (IOException ex) {
-                throw new RuntimeException("can't initialize Jigawatts",ex);
+        try {
+            System.loadLibrary("Jigawatts");
+        } catch (UnsatisfiedLinkError e) {
+            String libDir = System.getProperty("java.io.tmpdir");
+            String tmpLib = libDir+ "/" + System.mapLibraryName("Jigawatts");
+
+            if (!Files.exists(Paths.get(tmpLib))) {
+                try {
+                    copyLibrary("Jigawatts", libDir);
+                } catch (IOException ex) {
+                    throw new RuntimeException("can't initialize Jigawatts",ex);
+                }
             }
+            System.load(tmpLib);
         }
-        System.load(tmpLib);
         System.loadLibrary("criu");
 
         checkpointHooks = new ArrayList<Hook>();

--- a/src/main/java/org/openjdk/jigawatts/package-info.java
+++ b/src/main/java/org/openjdk/jigawatts/package-info.java
@@ -1,0 +1,3 @@
+@org.osgi.annotation.bundle.Export
+@org.osgi.annotation.versioning.Version("1.0")
+package org.openjdk.jigawatts;


### PR DESCRIPTION
I would like to use this library as an OSGi bundle.  This PR adds the necessary meta-data to build an OSGi bundle:

- Package `org.checkpoint` is exported as API
- OSGi Bundle-NativeCode header is used to inform the framework about native library
- Try `System.loadLibrary("CheckpointRestore")` first to allow the OSGi class loader to locate the native library packaged in the JAR before doing the manual extraction of the library to the /tmp folder.

This PR also includes adding common patterns to exclude to the `.gitignore`.

It also fixes the RandomTest package name.  This test is in the package directory for org/checkpoint but it was using the default (empty) package name in the source.  While javac and the maven usage of the java compiler cares nothing about the directory `.java` source files are located, I know some IDEs will give errors by default if it detects this type of thing.  I think it would be nice to follow the convention if possible. 