### PR TITLE
Bring back a Makefile for building to avoid Maven dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,11 @@
 /target/
 /nbproject/
+Makefile.in
+aclocal.m4
+autom4te.cache/
+compile
+config.guess
+config.sub
+configure
+install-sh
+missing

--- a/MANIFEST.MF.in
+++ b/MANIFEST.MF.in
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+Build-Jdk-Spec: @JDK_VERSION@
+JavaPackages-GroupId: @GROUP@
+JavaPackages-ArtifactId: @ARTIFACT@
+JavaPackages-Version: @PACKAGE_VERSION@

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,144 @@
+#  Copyright 2021 Red Hat, Inc.
+#
+#  This file is part of Jigawatt.
+#
+#  Jigawatt is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published
+#  by the Free Software Foundation; either version 2, or (at your
+#  option) any later version.
+#
+#  Jigawatt is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Jigawatt; see the file COPYING.  If not see
+#  <http://www.gnu.org/licenses/>.
+#
+#  Linking this library statically or dynamically with other modules
+#  is making a combined work based on this library.  Thus, the terms
+#  and conditions of the GNU General Public License cover the whole
+#  combination.
+#
+#  As a special exception, the copyright holders of this library give you
+#  permission to link this library with independent modules to produce an
+#  executable, regardless of the license terms of these independent
+#  modules, and to copy and distribute the resulting executable under
+#  terms of your choice, provided that you also meet, for each linked
+#  independent module, the terms and conditions of the license of that
+#  module.  An independent module is a module which is not derived from
+#  or based on this library.  If you modify this library, you may extend
+#  this exception to your version of the library, but you are not
+#  obligated to do so.  If you do not wish to do so, delete this
+#  exception statement from your version.
+
+JIGA_BUILDDIR = $(abs_top_builddir)/build
+JIGA_STAMPDIR = $(abs_top_builddir)/stamps
+JIGA_INCLUDEDIR = $(JIGA_BUILDDIR)/include
+JIGA_SRCDIR = $(abs_top_srcdir)/src/main
+JIGA_NATIVE_SRCDIR = $(JIGA_SRCDIR)/cpp
+JIGA_JAVA_SRCDIR = $(JIGA_SRCDIR)/java
+JIGA_MAVEN_DIR = META-INF/maven/$(GROUP)/$(ARTIFACT)
+
+JIGA_NATIVE_FUNCS = org/openjdk/jigawatts/Jigawatts.java
+JIGA_NATIVE_HDRS = $(subst .java,.h,$(subst /,_,$(JIGA_NATIVE_FUNCS)))
+JIGA_NATIVE_SRC = $(subst .java,.cpp,$(subst /,_,$(JIGA_NATIVE_FUNCS)))
+JIGA_NATIVE_OBJS = $(subst .cpp,.o,$(JIGA_NATIVE_SRC))
+JIGA_LIB = libJigawatts.so
+JIGA_JAR = $(ARTIFACT).jar
+
+LICENSE_DIR = $(datadir)/licenses/$(PACKAGE)
+JAVADOC_DIR = $(datadir)/javadoc/$(PACKAGE)
+JAR_DIR = $(datadir)/java/$(PACKAGE)
+
+EXTRA_DIST = src README.md LICENSE.md pom.xml
+
+JAVADOCFLAGS = -private -use -version -Xdoclint:none -encoding 'UTF-8' -charset 'UTF-8' -docencoding 'UTF-8'
+JAVADOC_ARGS = $(JAVADOCFLAGS) -d $(JIGA_BUILDDIR)/doc -sourcepath $(JIGA_JAVA_SRCDIR) \
+	  -classpath $(JIGA_BUILDDIR) -doctitle 'Javadoc for package $(PACKAGE)'
+
+all-local: $(JIGA_BUILDDIR)/$(JIGA_JAR) $(JIGA_BUILDDIR)/$(JIGA_LIB) $(JIGA_STAMPDIR)/docs.stamp
+
+.PHONY: clean-lib clean-native-objects clean-classes-and-headers clean-jar clean-docs clean-source-file-list
+
+clean-local: clean-lib clean-native-objects clean-classes-and-headers clean-jar clean-docs clean-source-file-list
+	$(RMDIR) build stamps
+
+$(JIGA_BUILDDIR)/source-files.txt:
+	mkdir -p $(JIGA_BUILDDIR)
+	find $(JIGA_JAVA_SRCDIR) -name '*.java' | sort > $@ ;
+	touch $@
+
+clean-source-file-list:
+	$(RM) $(JIGA_BUILDDIR)/source-files.txt
+
+$(JIGA_STAMPDIR)/classes.stamp: $(JIGA_BUILDDIR)/source-files.txt
+	$(SYSTEM_JDK_DIR)/bin/javac -g $(JAVACFLAGS) \
+	      -d $(JIGA_BUILDDIR) -h $(JIGA_INCLUDEDIR) \
+	      -sourcepath $(JIGA_JAVA_SRCDIR) \
+	      @$< ;
+	mkdir -p $(JIGA_STAMPDIR)
+	touch $@
+
+clean-classes-and-headers:
+	$(RM) $(addprefix $(JIGA_INCLUDEDIR)/,$(JIGA_NATIVE_HDRS))
+	$(RM) -r $(JIGA_BUILDDIR)/org
+	$(RM) $(JIGA_STAMPDIR)/classes.stamp
+
+$(JIGA_BUILDDIR)/%.o: $(JIGA_NATIVE_SRCDIR)/%.cpp
+	$(CC) $(CFLAGS) -I$(SYSTEM_JDK_DIR)/include \
+	  -I$(SYSTEM_JDK_DIR)/include/linux -I$(JIGA_INCLUDEDIR) $(CRIU_CFLAGS) \
+	  -fPIC -o $@ -c $<
+
+clean-native-objects:
+	$(RM) $(addprefix $(JIGA_BUILDDIR)/,$(JIGA_NATIVE_OBJS))
+
+$(JIGA_BUILDDIR)/$(JIGA_LIB): $(addprefix $(JIGA_INCLUDEDIR)/,$(JIGA_NATIVE_HDRS)) \
+  $(addprefix $(JIGA_BUILDDIR)/,$(JIGA_NATIVE_OBJS))
+	$(CC) $(LDFLAGS) $(addprefix $(JIGA_BUILDDIR)/,$(JIGA_NATIVE_OBJS)) -shared -o $@ $(CRIU_LIBS)
+
+clean-lib:
+	$(RM) $(JIGA_BUILDDIR)/$(JIGA_LIB)
+
+$(JIGA_BUILDDIR)/$(JIGA_JAR): $(JIGA_STAMPDIR)/classes.stamp
+	cd $(JIGA_BUILDDIR) && \
+	  $(MKDIR_P) $(JIGA_MAVEN_DIR) && \
+	  cp $(abs_top_srcdir)/pom.xml $(abs_top_builddir)/pom.properties $(JIGA_MAVEN_DIR) && \
+	  $(SYSTEM_JDK_DIR)/bin/jar -cvfm $(JIGA_JAR) $(abs_top_builddir)/MANIFEST.MF ./org META-INF
+
+clean-jar:
+	$(RM) $(JIGA_BUILDDIR)/$(JIGA_JAR)
+	$(RM) -r $(JIGA_BUILDDIR)/$(JIGA_MAVEN_DIR)
+
+$(JIGA_STAMPDIR)/docs.stamp: $(JIGA_BUILDDIR)/source-files.txt
+	$(SYSTEM_JDK_DIR)/bin/javadoc $(JAVADOC_ARGS) @$< ;
+	for word in $(JAVADOC_ARGS); do echo $${word} >> $(JIGA_BUILDDIR)/doc/args; done
+	mkdir -p $(JIGA_STAMPDIR)
+	touch $@
+
+clean-docs:
+	$(RM) -r $(JIGA_BUILDDIR)/doc
+	$(RM) $(JIGA_STAMPDIR)/docs.stamp
+
+install-exec-local:
+	${mkinstalldirs} $(DESTDIR)$(JAR_DIR) $(DESTDIR)/$(libdir)
+	$(INSTALL_DATA) $(JIGA_BUILDDIR)/$(JIGA_JAR) $(DESTDIR)$(JAR_DIR)
+	$(INSTALL_PROGRAM) $(JIGA_BUILDDIR)/$(JIGA_LIB) $(DESTDIR)$(libdir)
+
+install-data-local:
+	$(mkinstalldirs) $(DESTDIR)$(LICENSE_DIR) $(DESTDIR)$(docdir)
+	$(mkinstalldirs) $(DESTDIR)$(JAVADOC_DIR)
+	$(INSTALL_DATA) $(abs_top_srcdir)/README.md $(DESTDIR)$(docdir)
+	$(INSTALL_DATA) $(abs_top_srcdir)/LICENSE.md $(DESTDIR)$(LICENSE_DIR)
+	cp -RP $(JIGA_BUILDDIR)/doc/* $(DESTDIR)$(JAVADOC_DIR)
+
+uninstall-local:
+	$(RM) -v $(DESTDIR)$(JAR_DIR)/$(JIGA_JAR)
+	$(RMDIR) $(DESTDIR)$(JAR_DIR)
+	$(RM) -v $(DESTDIR)$(libdir)/$(JIGA_LIB)
+	$(RM) -v $(DESTDIR)$(docdir)/README.md
+	$(RMDIR) $(DESTDIR)$(docdir)
+	$(RM) -v $(DESTDIR)$(LICENSE_DIR)/LICENSE.md
+	$(RMDIR) $(DESTDIR)$(LICENSE_DIR)
+	$(RM) -rv $(DESTDIR)$(JAVADOC_DIR)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ Caveats:
    
    You must run tests as root.  CRIU will run in user mode eventually, but not everywhere yet.
 
+## Building with autotools
+
+```
+$ mkdir <build_dir>
+$ <src_dir>/configure --prefix=<install prefix>
+$ make
+$ make install
+```
+
 ## Building with Maven (experimental)
 
 ```

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Caveats:
 
 ## Building with autotools
 
+The source directory can be obtained either from a release tarball
+or a checkout of the git source code repository.  When using the
+git repository, it is necessary to install the automake and autoconf
+tools and run `autogen.sh` to create the configure script.
+
 ```
 $ mkdir <build_dir>
 $ <src_dir>/configure --prefix=<install prefix>

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1,0 +1,146 @@
+dnl Copyright 2021 Red Hat, Inc.
+dnl
+dnl This file is part of Jigawatt.
+dnl
+dnl Jigawatt is free software; you can redistribute it and/or modify
+dnl it under the terms of the GNU General Public License as published
+dnl by the Free Software Foundation; either version 2, or (at your
+dnl option) any later version.
+dnl
+dnl Jigawatt is distributed in the hope that it will be useful, but
+dnl WITHOUT ANY WARRANTY; without even the implied warranty of
+dnl MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+dnl General Public License for more details.
+dnl
+dnl You should have received a copy of the GNU General Public License
+dnl along with Jigawatt; see the file COPYING.  If not see
+dnl <http://www.gnu.org/licenses/>.
+dnl
+dnl Linking this library statically or dynamically with other modules
+dnl is making a combined work based on this library.  Thus, the terms
+dnl and conditions of the GNU General Public License cover the whole
+dnl combination.
+dnl
+dnl As a special exception, the copyright holders of this library give you
+dnl permission to link this library with independent modules to produce an
+dnl executable, regardless of the license terms of these independent
+dnl modules, and to copy and distribute the resulting executable under
+dnl terms of your choice, provided that you also meet, for each linked
+dnl independent module, the terms and conditions of the license of that
+dnl module.  An independent module is a module which is not derived from
+dnl or based on this library.  If you modify this library, you may extend
+dnl this exception to your version of the library, but you are not
+dnl obligated to do so.  If you do not wish to do so, delete this
+dnl exception statement from your version.
+
+dnl Utility macros for jigawatts build
+
+AC_DEFUN_ONCE([JW_CHECK_FOR_JDK],
+[
+  AC_MSG_CHECKING([for a JDK home directory])
+  AC_ARG_WITH([jdk-home],
+	      [AS_HELP_STRING([--with-jdk-home[[=PATH]]],
+                              [jdk home directory (default is first predefined JDK found)])],
+              [
+                if test "x${withval}" = xyes
+                then
+                  SYSTEM_JDK_DIR=
+                elif test "x${withval}" = xno
+                then
+	          SYSTEM_JDK_DIR=
+	        else
+                  SYSTEM_JDK_DIR=${withval}
+                fi
+              ],
+              [
+	        SYSTEM_JDK_DIR=
+              ])
+  if test -z "${SYSTEM_JDK_DIR}"; then
+    AC_MSG_RESULT([not specified])
+    OPENJDK8_VMS="/usr/lib/jvm/icedtea-8 /usr/lib/jvm/java-1.8.0-openjdk
+    		  /usr/lib/jvm/java-1.8.0-openjdk.${RPM_ARCH} /usr/lib64/jvm/java-1.8.0-openjdk
+		  /usr/lib/jvm/java-1.8.0 /usr/lib/jvm/java-8-openjdk"
+    for dir in /usr/lib/jvm/java-openjdk /usr/lib/jvm/openjdk /usr/lib/jvm/java-icedtea \
+	       /etc/alternatives/java_sdk_openjdk ${OPENJDK8_VMS} ; do
+       AC_MSG_CHECKING([for ${dir}]);
+       if test -d $dir; then
+         SYSTEM_JDK_DIR=$dir ;
+	 AC_MSG_RESULT([found]) ;
+	 break ;
+       else
+         AC_MSG_RESULT([not found]) ;
+       fi
+    done
+  else
+    AC_MSG_RESULT(${SYSTEM_JDK_DIR})
+  fi
+  if ! test -d "${SYSTEM_JDK_DIR}"; then
+    AC_MSG_ERROR("A JDK home directory could not be found.")
+  fi
+  AC_SUBST(SYSTEM_JDK_DIR)
+])
+
+AC_DEFUN_ONCE([JW_CHECK_FOR_JDK_VERSION],
+[
+  AC_REQUIRE([JW_CHECK_FOR_JDK])
+  AC_CACHE_CHECK([for the JDK version], jw_cv_jdk_version, [
+  CLASS=Test.java
+  BYTECODE=$(echo $CLASS|sed 's#\.java##')
+  mkdir tmp.$$
+  cd tmp.$$
+  cat << \EOF > $CLASS
+[/* [#]line __oline__ "configure" */
+
+public class Test
+{
+    public static void main(String[] args)
+    {
+      System.out.println(System.getProperty("java.specification.version"));
+    }
+}]
+EOF
+  if ${SYSTEM_JDK_DIR}/bin/javac -cp . $JAVACFLAGS -source 8 -target 8 $CLASS >&AS_MESSAGE_LOG_FD 2>&1; then
+    if ${SYSTEM_JDK_DIR}/bin/java -classpath . $BYTECODE >&AS_MESSAGE_LOG_FD 2>&1; then
+      JDK_VERSION=$(${SYSTEM_JDK_DIR}/bin/java -classpath . $BYTECODE);
+      jw_cv_jdk_version=${JDK_VERSION};
+    else
+      jw_cv_jdk_version=no;
+      AC_MSG_ERROR([VM failed to run compiled class.])
+    fi
+  else
+    jw_cv_jdk_version=no;
+    AC_MSG_ERROR([Compiler failed to compile Java code.])
+  fi
+  rm -f $CLASS *.class
+  cd ..
+  rmdir tmp.$$
+  ])
+AC_SUBST([JDK_VERSION])
+AC_PROVIDE([$0])dnl
+])
+)
+
+AC_DEFUN_ONCE([JW_FIND_TOOL],
+[AC_PATH_TOOL([$1],[$2])
+ if test x"$$1" = x ; then
+   AC_MSG_ERROR([The following program was not found on the PATH: $2])
+ fi
+ AC_SUBST([$1])
+])
+
+AC_DEFUN_ONCE([JW_CHECK_FOR_RMDIR],
+[
+  JW_FIND_TOOL([RMDIR],[rmdir])
+  AC_CACHE_CHECK([if ${RMDIR} supports --ignore-fail-on-non-empty], jw_cv_RMDIR, [
+    mkdir tmp.$$
+    touch tmp.$$/t
+    if ${RMDIR} --ignore-fail-on-non-empty tmp.$$ >&AS_MESSAGE_LOG_FD 2>&1; then
+       jw_cv_RMDIR=yes;
+       RMDIR="${RMDIR} --ignore-fail-on-non-empty"
+    else
+       jw_cv_RMDIR=no;
+    fi
+  ])
+  rm -f tmp.$$/t
+  ${RMDIR} tmp.$$
+])

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,161 @@
+#!/bin/sh
+
+#  Copyright 2021 Red Hat, Inc.
+#
+#  This file is part of Jigawatt.
+#
+#  Jigawatt is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published
+#  by the Free Software Foundation; either version 2, or (at your
+#  option) any later version.
+#
+#  Jigawatt is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Jigawatt; see the file COPYING.  If not see
+#  <http://www.gnu.org/licenses/>.
+#
+#  Linking this library statically or dynamically with other modules
+#  is making a combined work based on this library.  Thus, the terms
+#  and conditions of the GNU General Public License cover the whole
+#  combination.
+#
+#  As a special exception, the copyright holders of this library give you
+#  permission to link this library with independent modules to produce an
+#  executable, regardless of the license terms of these independent
+#  modules, and to copy and distribute the resulting executable under
+#  terms of your choice, provided that you also meet, for each linked
+#  independent module, the terms and conditions of the license of that
+#  module.  An independent module is a module which is not derived from
+#  or based on this library.  If you modify this library, you may extend
+#  this exception to your version of the library, but you are not
+#  obligated to do so.  If you do not wish to do so, delete this
+#  exception statement from your version.
+
+# Test for autoconf commands.
+
+# Test for autoconf.
+
+HAVE_AUTOCONF=false
+
+for AUTOCONF in autoconf autoconf259; do
+    if ${AUTOCONF} --version > /dev/null 2>&1; then
+        AUTOCONF_VERSION=`${AUTOCONF} --version | head -1 | sed 's/^[^0-9]*\([0-9.][0-9.]*\).*/\1/'`
+#        echo ${AUTOCONF_VERSION}
+        case ${AUTOCONF_VERSION} in
+            2.59* | 2.6[0-9]* )
+                HAVE_AUTOCONF=true
+                break;
+                ;;
+        esac
+    fi
+done
+
+# Test for autoheader.
+
+HAVE_AUTOHEADER=false
+
+for AUTOHEADER in autoheader autoheader259; do
+    if ${AUTOHEADER} --version > /dev/null 2>&1; then
+        AUTOHEADER_VERSION=`${AUTOHEADER} --version | head -1 | sed 's/^[^0-9]*\([0-9.][0-9.]*\).*/\1/'`
+#        echo ${AUTOHEADER_VERSION}
+        case ${AUTOHEADER_VERSION} in
+            2.59* | 2.6[0-9]* )
+                HAVE_AUTOHEADER=true
+                break;
+                ;;
+        esac
+    fi
+done
+
+# Test for autoreconf.
+
+HAVE_AUTORECONF=false
+
+for AUTORECONF in autoreconf; do
+    if ${AUTORECONF} --version > /dev/null 2>&1; then
+        AUTORECONF_VERSION=`${AUTORECONF} --version | head -1 | sed 's/^[^0-9]*\([0-9.][0-9.]*\).*/\1/'`
+#        echo ${AUTORECONF_VERSION}
+        case ${AUTORECONF_VERSION} in
+            2.59* | 2.6[0-9]* )
+                HAVE_AUTORECONF=true
+                break;
+                ;;
+        esac
+    fi
+done
+
+if test ${HAVE_AUTOCONF} = false; then
+    echo "No proper autoconf was found."
+    echo "You must have autoconf 2.59 or later installed."
+    exit 1
+fi
+
+if test ${HAVE_AUTOHEADER} = false; then
+    echo "No proper autoheader was found."
+    echo "You must have autoconf 2.59 or later installed."
+    exit 1
+fi
+
+if test ${HAVE_AUTORECONF} = false; then
+    echo "No proper autoreconf was found."
+    echo "You must have autoconf 2.59 or later installed."
+    exit 1
+fi
+
+
+# Test for automake commands.
+
+# Test for aclocal.
+
+HAVE_ACLOCAL=false
+
+for ACLOCAL in aclocal aclocal-1.10; do
+    if ${ACLOCAL} --version > /dev/null 2>&1; then
+        ACLOCAL_VERSION=`${ACLOCAL} --version | head -1 | sed 's/^[^0-9]*\([0-9.][0-9.]*\).*/\1/'`
+#        echo ${ACLOCAL_VERSION}
+        case ${ACLOCAL_VERSION} in
+            1.9.[6-9] | 1.1[0-9]* )
+                HAVE_ACLOCAL=true
+                break;
+                ;;
+        esac
+    fi
+done
+
+# Test for automake.
+
+HAVE_AUTOMAKE=false
+
+for AUTOMAKE in automake automake-1.10; do
+    if ${AUTOMAKE} --version > /dev/null 2>&1; then
+        AUTOMAKE_VERSION=`${AUTOMAKE} --version | head -1 | sed 's/^[^0-9]*\([0-9.][0-9.]*\).*/\1/'`
+#        echo ${AUTOMAKE_VERSION}
+        case ${AUTOMAKE_VERSION} in
+            1.9.[6-9] | 1.1[0-9]* )
+                HAVE_AUTOMAKE=true
+                break;
+                ;;
+        esac
+    fi
+done
+
+if test ${HAVE_ACLOCAL} = false; then
+    echo "No proper aclocal was found."
+    echo "You must have automake 1.9.6 or later installed."
+    exit 1
+fi
+
+if test ${HAVE_AUTOMAKE} = false; then
+    echo "No proper automake was found."
+    echo "You must have automake 1.9.6 or later installed."
+    exit 1
+fi
+
+
+export ACLOCAL AUTOCONF AUTOHEADER AUTOMAKE
+
+${AUTORECONF} --force --install

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,62 @@
+dnl Copyright 2021 Red Hat, Inc.
+dnl
+dnl This file is part of Jigawatt.
+dnl
+dnl Jigawatt is free software; you can redistribute it and/or modify
+dnl it under the terms of the GNU General Public License as published
+dnl by the Free Software Foundation; either version 2, or (at your
+dnl option) any later version.
+dnl
+dnl Jigawatt is distributed in the hope that it will be useful, but
+dnl WITHOUT ANY WARRANTY; without even the implied warranty of
+dnl MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+dnl General Public License for more details.
+dnl
+dnl You should have received a copy of the GNU General Public License
+dnl along with Jigawatt; see the file COPYING.  If not see
+dnl <http://www.gnu.org/licenses/>.
+dnl
+dnl Linking this library statically or dynamically with other modules
+dnl is making a combined work based on this library.  Thus, the terms
+dnl and conditions of the GNU General Public License cover the whole
+dnl combination.
+dnl
+dnl As a special exception, the copyright holders of this library give you
+dnl permission to link this library with independent modules to produce an
+dnl executable, regardless of the license terms of these independent
+dnl modules, and to copy and distribute the resulting executable under
+dnl terms of your choice, provided that you also meet, for each linked
+dnl independent module, the terms and conditions of the license of that
+dnl module.  An independent module is a module which is not derived from
+dnl or based on this library.  If you modify this library, you may extend
+dnl this exception to your version of the library, but you are not
+dnl obligated to do so.  If you do not wish to do so, delete this
+dnl exception statement from your version.
+
+AC_INIT([jigawatts], [1.0-SNAPSHOT], [chf@redhat.com])
+AC_CANONICAL_HOST
+AC_CANONICAL_TARGET
+AM_INIT_AUTOMAKE([1.9 tar-pax foreign])
+AM_MAINTAINER_MODE([enable])
+AC_CONFIG_FILES([Makefile pom.properties MANIFEST.MF])
+
+AC_PROG_CC
+
+JW_CHECK_FOR_JDK_VERSION
+JW_CHECK_FOR_RMDIR
+
+dnl Check for CRIU
+PKG_CHECK_MODULES(CRIU,criu,[CRIU_FOUND=yes],[CRIU_FOUND=no])
+if test "x${CRIU_FOUND}" = xno
+then
+  AC_MSG_ERROR([Could not find CRIU headers - Try installing criu-devel.])
+fi
+AC_SUBST(CRIU_CFLAGS)
+AC_SUBST(CRIU_LIBS)
+
+GROUP=org.openjdk
+ARTIFACT=jigawatt
+AC_SUBST(GROUP)
+AC_SUBST(ARTIFACT)
+
+AC_OUTPUT

--- a/pom.properties.in
+++ b/pom.properties.in
@@ -1,0 +1,3 @@
+artifactId=@ARTIFACT@
+groupId=@GROUP@
+version=@PACKAGE_VERSION@


### PR DESCRIPTION
The required Maven dependencies are not available on all systems, making it difficult to package jigawatts. There is also little control in how the native library is being built in the current Maven build system.

This patch adds a simple autotools-based system which handles CFLAGS, LDFLAGS, etc. and the usual installation prefixes in the standard way. It has passed a [make distcheck](https://www.gnu.org/software/automake/manual/html_node/Checking-the-Distribution.html), meaning the build can produce a tarball and this can then be used to perform a full build and install.

It doesn't currently support the tests, but these can be added as needed. It doesn't seem a good idea until they can be run without root privileges (which makes them unusable in a packaging environment)