### PR TITLE
To be Jigawatts or to be Jigawatt, that is the question.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,19 +1,19 @@
 #  Copyright 2021 Red Hat, Inc.
 #
-#  This file is part of Jigawatt.
+#  This file is part of Jigawatts.
 #
-#  Jigawatt is free software; you can redistribute it and/or modify
+#  Jigawatts is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published
 #  by the Free Software Foundation; either version 2, or (at your
 #  option) any later version.
 #
-#  Jigawatt is distributed in the hope that it will be useful, but
+#  Jigawatts is distributed in the hope that it will be useful, but
 #  WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 #  General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with Jigawatt; see the file COPYING.  If not see
+#  along with Jigawatts; see the file COPYING.  If not see
 #  <http://www.gnu.org/licenses/>.
 #
 #  Linking this library statically or dynamically with other modules

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1,19 +1,19 @@
 dnl Copyright 2021 Red Hat, Inc.
 dnl
-dnl This file is part of Jigawatt.
+dnl This file is part of Jigawatts.
 dnl
-dnl Jigawatt is free software; you can redistribute it and/or modify
+dnl Jigawatts is free software; you can redistribute it and/or modify
 dnl it under the terms of the GNU General Public License as published
 dnl by the Free Software Foundation; either version 2, or (at your
 dnl option) any later version.
 dnl
-dnl Jigawatt is distributed in the hope that it will be useful, but
+dnl Jigawatts is distributed in the hope that it will be useful, but
 dnl WITHOUT ANY WARRANTY; without even the implied warranty of
 dnl MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 dnl General Public License for more details.
 dnl
 dnl You should have received a copy of the GNU General Public License
-dnl along with Jigawatt; see the file COPYING.  If not see
+dnl along with Jigawatts; see the file COPYING.  If not see
 dnl <http://www.gnu.org/licenses/>.
 dnl
 dnl Linking this library statically or dynamically with other modules

--- a/autogen.sh
+++ b/autogen.sh
@@ -2,20 +2,20 @@
 
 #  Copyright 2021 Red Hat, Inc.
 #
-#  This file is part of Jigawatt.
+#  This file is part of Jigawatts.
 #
-#  Jigawatt is free software; you can redistribute it and/or modify
+#  Jigawatts is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published
 #  by the Free Software Foundation; either version 2, or (at your
 #  option) any later version.
 #
-#  Jigawatt is distributed in the hope that it will be useful, but
+#  Jigawatts is distributed in the hope that it will be useful, but
 #  WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 #  General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with Jigawatt; see the file COPYING.  If not see
+#  along with Jigawatts; see the file COPYING.  If not see
 #  <http://www.gnu.org/licenses/>.
 #
 #  Linking this library statically or dynamically with other modules

--- a/configure.ac
+++ b/configure.ac
@@ -1,19 +1,19 @@
 dnl Copyright 2021 Red Hat, Inc.
 dnl
-dnl This file is part of Jigawatt.
+dnl This file is part of Jigawatts.
 dnl
-dnl Jigawatt is free software; you can redistribute it and/or modify
+dnl Jigawatts is free software; you can redistribute it and/or modify
 dnl it under the terms of the GNU General Public License as published
 dnl by the Free Software Foundation; either version 2, or (at your
 dnl option) any later version.
 dnl
-dnl Jigawatt is distributed in the hope that it will be useful, but
+dnl Jigawatts is distributed in the hope that it will be useful, but
 dnl WITHOUT ANY WARRANTY; without even the implied warranty of
 dnl MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 dnl General Public License for more details.
 dnl
 dnl You should have received a copy of the GNU General Public License
-dnl along with Jigawatt; see the file COPYING.  If not see
+dnl along with Jigawatts; see the file COPYING.  If not see
 dnl <http://www.gnu.org/licenses/>.
 dnl
 dnl Linking this library statically or dynamically with other modules

--- a/pom.xml
+++ b/pom.xml
@@ -1,20 +1,20 @@
 <!--
  - Copyright 2021 Red Hat, Inc.
  -
- - This file is part of Jigawatt.
+ - This file is part of Jigawatts.
  -
- - Jigawatt is free software; you can redistribute it and/or modify
+ - Jigawatts is free software; you can redistribute it and/or modify
  - it under the terms of the GNU General Public License as published
  - by the Free Software Foundation; either version 2, or (at your
  - option) any later version.
  -
- - Jigawatt is distributed in the hope that it will be useful, but
+ - Jigawatts is distributed in the hope that it will be useful, but
  - WITHOUT ANY WARRANTY; without even the implied warranty of
  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  - General Public License for more details.
  -
  - You should have received a copy of the GNU General Public License
- - along with Jigawatt; see the file COPYING.  If not see
+ - along with Jigawatts; see the file COPYING.  If not see
  - <http://www.gnu.org/licenses/>.
  -
  - Linking this library statically or dynamically with other modules
@@ -45,7 +45,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>Jigawatt</name>
+    <name>Jigawatts</name>
 
     <properties>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -137,7 +137,7 @@
                 <version>3.2.4</version>
                 <executions>
                     <execution>
-                        <id>jigawatt</id>
+                        <id>jigawatts</id>
                         <phase>package</phase>
                         <goals>
                             <goal>shade</goal>


### PR DESCRIPTION
Corrects the usage of "Jigawatt" intead of "Jigawatts" across the source code base.

Originally had the changes in https://github.com/chflood/jigawatts/pull/18 as well, which was merged as I was committing this :)