### PR TITLE
Fix autotools build following package rename.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -105,7 +105,8 @@ clean-lib:
 $(JIGA_BUILDDIR)/$(JIGA_JAR): $(JIGA_STAMPDIR)/classes.stamp
 	cd $(JIGA_BUILDDIR) && \
 	  $(MKDIR_P) $(JIGA_MAVEN_DIR) && \
-	  cp $(abs_top_srcdir)/pom.xml $(abs_top_builddir)/autotools.pom.properties $(JIGA_MAVEN_DIR) && \
+	  cp $(abs_top_srcdir)/pom.xml $(JIGA_MAVEN_DIR) && \
+	  cp $(abs_top_builddir)/autotools.pom.properties $(JIGA_MAVEN_DIR)/pom.properties && \
 	  $(SYSTEM_JDK_DIR)/bin/jar -cvfm $(JIGA_JAR) $(abs_top_builddir)/MANIFEST.MF ./$(JAVA_ROOT_DIR) META-INF
 
 clean-jar:

--- a/Makefile.am
+++ b/Makefile.am
@@ -47,6 +47,7 @@ JIGA_NATIVE_SRC = $(subst .java,.cpp,$(subst /,_,$(JIGA_NATIVE_FUNCS)))
 JIGA_NATIVE_OBJS = $(subst .cpp,.o,$(JIGA_NATIVE_SRC))
 JIGA_LIB = libJigawatts.so
 JIGA_JAR = $(ARTIFACT).jar
+JAVA_ROOT_DIR = $(word 1, $(subst /, ,$(JIGA_NATIVE_FUNCS)))
 
 LICENSE_DIR = $(datadir)/licenses/$(PACKAGE)
 JAVADOC_DIR = $(datadir)/javadoc/$(PACKAGE)
@@ -83,7 +84,7 @@ $(JIGA_STAMPDIR)/classes.stamp: $(JIGA_BUILDDIR)/source-files.txt
 
 clean-classes-and-headers:
 	$(RM) $(addprefix $(JIGA_INCLUDEDIR)/,$(JIGA_NATIVE_HDRS))
-	$(RM) -r $(JIGA_BUILDDIR)/org
+	$(RM) -r $(JIGA_BUILDDIR)/$(JAVA_ROOT_DIR)
 	$(RM) $(JIGA_STAMPDIR)/classes.stamp
 
 $(JIGA_BUILDDIR)/%.o: $(JIGA_NATIVE_SRCDIR)/%.cpp
@@ -105,7 +106,7 @@ $(JIGA_BUILDDIR)/$(JIGA_JAR): $(JIGA_STAMPDIR)/classes.stamp
 	cd $(JIGA_BUILDDIR) && \
 	  $(MKDIR_P) $(JIGA_MAVEN_DIR) && \
 	  cp $(abs_top_srcdir)/pom.xml $(abs_top_builddir)/autotools.pom.properties $(JIGA_MAVEN_DIR) && \
-	  $(SYSTEM_JDK_DIR)/bin/jar -cvfm $(JIGA_JAR) $(abs_top_builddir)/MANIFEST.MF ./org META-INF
+	  $(SYSTEM_JDK_DIR)/bin/jar -cvfm $(JIGA_JAR) $(abs_top_builddir)/MANIFEST.MF ./$(JAVA_ROOT_DIR) META-INF
 
 clean-jar:
 	$(RM) $(JIGA_BUILDDIR)/$(JIGA_JAR)


### PR DESCRIPTION
The package rename missed a stray 'org' used in Makefile.am. I've adapted the build so it works out the Java root directory from the path to Jigawatts.java to remove this point of failure in future.

There was also an issue with the renaming of pom.properties which meant it was installed in the JAR file under the new name. It should still be pom.properties in the JAR file so the output is the same from either build.