### PR TITLE
Crosscompile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,147 +48,149 @@
     <name>Jigawatts</name>
 
     <properties>
-      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <java.includes>${env.JAVA_HOME}</java.includes>      
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.includes>${env.JAVA_HOME}</java.includes>
     </properties>
-    
+
     <dependencies>
-        
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>5.7.0</version>
             <scope>test</scope>
         </dependency>
-        
+
     </dependencies>
 
-<profiles>
-    <profile>
-        <id>natives</id>
-        <activation>
-            <activeByDefault>true</activeByDefault>
-        </activation>
-        <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>3.0.0</version>
-                <executions>
-                    <execution>
-                        <id>compile-cpp</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>process-classes</phase>
+    <profiles>
+        <profile>
+            <id>natives</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.0.0</version>
+                        <executions>
+                            <execution>
+                                <id>compile-cpp</id>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <phase>process-classes</phase>
+                                <configuration>
+                                    <executable>gcc</executable>
+                                    <arguments>
+                                        <argument>-v</argument>
+                                        <argument>-shared</argument>
+                                        <argument>-fPIC</argument>
+                                        <argument>-I${java.includes}/include</argument>
+                                        <argument>-I${java.includes}/include/linux</argument>
+                                        <argument>-I/usr/lib64/</argument>
+                                        <argument>-I/usr/include/criu</argument>
+                                        <argument>-I${project.build.directory}/native/javah</argument>
+                                        <argument>-lcriu</argument>
+                                        <argument>-o${project.build.outputDirectory}/libJigawatts.so</argument>
+                                        <argument>${project.basedir}/src/main/cpp/com_redhat_jigawatts_Jigawatts.cpp
+                                        </argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>java</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.8.1</version>
                         <configuration>
-                            <executable>gcc</executable>
-                            <arguments>
-                                <argument>-v</argument>
-                                <argument>-shared</argument>
-                                <argument>-fPIC</argument>
-                                <argument>-I${java.includes}/include</argument>
-                                <argument>-I${java.includes}/include/linux</argument>
-                                <argument>-I/usr/lib64/</argument>
-                                <argument>-I/usr/include/criu</argument>
-                                <argument>-I${project.build.directory}/native/javah</argument>
-                                <argument>-lcriu</argument>
-                                <argument>-o${project.build.outputDirectory}/libJigawatts.so</argument>
-                                <argument>${project.basedir}/src/main/cpp/com_redhat_jigawatts_Jigawatts.cpp</argument>
-                            </arguments>
+                            <compilerVersion>8</compilerVersion>
+                            <source>8</source>
+                            <target>8</target>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-    </profile>
-    <profile>
-        <id>java</id>
-        <activation>
-            <activeByDefault>true</activeByDefault>
-        </activation>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <compilerVersion>8</compilerVersion>
-                    <source>8</source>
-                    <target>8</target>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>header-generation</id>
-                        <phase>process-sources</phase>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                       <configuration>
-                            <compilerArgs>
-                                <arg>-h</arg>
-                                <arg>${project.build.directory}/native/javah</arg>
-                            </compilerArgs>
-                            <includes>
-                                 <include>com/redhat/jigawatts/Jigawatts.java</include>
-                            </includes>
-                      </configuration>
-                   </execution>
-               </executions>
-           </plugin>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
-                <configuration>
-                    <!-- TODO this only needed when printf is used in native code; can be remove once its gone -->
-                    <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
-                <executions>
-                    <execution>
-                        <id>jigawatts</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
+                        <executions>
+                            <execution>
+                                <id>header-generation</id>
+                                <phase>process-sources</phase>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                                <configuration>
+                                    <compilerArgs>
+                                        <arg>-h</arg>
+                                        <arg>${project.build.directory}/native/javah</arg>
+                                    </compilerArgs>
+                                    <includes>
+                                        <include>com/redhat/jigawatts/Jigawatts.java</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.0.0-M5</version>
                         <configuration>
-                            <finalName>jigawatts</finalName>
+                            <!-- TODO this only needed when printf is used in native code; can be remove once its gone -->
+                            <forkNode
+                                    implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-	    <plugin>
-	      <artifactId>maven-clean-plugin</artifactId>
-	      <version>3.1.0</version>
-	      <configuration>
-		<filesets>
-		  <fileset>
-		    <directory>src/test/resources</directory>
-		    <includes>
-		      <include>jigawatts/*</include>
-		      <include>1*</include>
-		    </includes>
-		    <followSymlinks>false</followSymlinks>
-		  </fileset>
-		</filesets>
-	      </configuration>
-	    </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.2.0</version>
-          <configuration>
-          </configuration>
-        </plugin>
-      </plugins>
-    </build>
-    </profile>
-</profiles>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <version>3.2.4</version>
+                        <executions>
+                            <execution>
+                                <id>jigawatts</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>shade</goal>
+                                </goals>
+                                <configuration>
+                                    <finalName>jigawatts</finalName>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-clean-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <configuration>
+                            <filesets>
+                                <fileset>
+                                    <directory>src/test/resources</directory>
+                                    <includes>
+                                        <include>jigawatts/*</include>
+                                        <include>1*</include>
+                                    </includes>
+                                    <followSymlinks>false</followSymlinks>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.2.0</version>
+                        <configuration>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,52 @@
         
     </dependencies>
 
+<profiles>
+    <profile>
+        <id>natives</id>
+        <activation>
+            <activeByDefault>true</activeByDefault>
+        </activation>
+        <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>compile-cpp</id>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <phase>process-classes</phase>
+                        <configuration>
+                            <executable>gcc</executable>
+                            <arguments>
+                                <argument>-v</argument>
+                                <argument>-shared</argument>
+                                <argument>-fPIC</argument>
+                                <argument>-I${java.includes}/include</argument>
+                                <argument>-I${java.includes}/include/linux</argument>
+                                <argument>-I/usr/lib64/</argument>
+                                <argument>-I/usr/include/criu</argument>
+                                <argument>-I${project.build.directory}/native/javah</argument>
+                                <argument>-lcriu</argument>
+                                <argument>-o${project.build.outputDirectory}/libJigawatts.so</argument>
+                                <argument>${project.basedir}/src/main/cpp/com_redhat_jigawatts_Jigawatts.cpp</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    </profile>
+    <profile>
+        <id>java</id>
+        <activation>
+            <activeByDefault>true</activeByDefault>
+        </activation>
     <build>
         <plugins>
             <plugin>
@@ -100,36 +146,6 @@
                     <!-- TODO this only needed when printf is used in native code; can be remove once its gone -->
                     <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>3.0.0</version>
-                <executions>
-                    <execution>
-                        <id>compile-cpp</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>process-classes</phase>
-                        <configuration>
-                            <executable>gcc</executable>
-                            <arguments>
-                                <argument>-v</argument>
-                                <argument>-shared</argument>
-                                <argument>-fPIC</argument>
-                                <argument>-I${java.includes}/include</argument>
-                                <argument>-I${java.includes}/include/linux</argument>
-                                <argument>-I/usr/lib64/</argument>
-                                <argument>-I/usr/include/criu</argument>
-                                <argument>-I${project.build.directory}/native/javah</argument>
-                                <argument>-lcriu</argument>
-                                <argument>-o${project.build.outputDirectory}/libJigawatts.so</argument>
-                                <argument>${project.basedir}/src/main/cpp/com_redhat_jigawatts_Jigawatts.cpp</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -173,4 +189,6 @@
         </plugin>
       </plugins>
     </build>
+    </profile>
+</profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,107 @@
             </build>
         </profile>
         <profile>
+            <id>crosscompile</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.0.0</version>
+                        <executions>
+                            <execution>
+                                <id>cross-compile-cpp-aarch64</id>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <phase>process-classes</phase>
+                                <configuration>
+                                    <!-- may not work under root!-->
+                                    <executable>aarch64-linux-gnu-gcc
+                                    </executable><!-- dnf install gcc-c++-aarch64-linux-gnu gcc-aarch64-linux-gnu -->
+                                    <arguments>
+                                        <argument>-v</argument>
+                                        <argument>-shared</argument>
+                                        <!--<argument>-static</argument> ???? can criu be static ????-->
+                                        <!-- mock  -r fedora-35-aarch64 -install glibc-devel glibc-static criu-devel -->
+                                        <argument>--sysroot=/var/lib/mock/fedora-35-aarch64/root/</argument>
+                                        <argument>-fPIC</argument>
+                                        <argument>-I${java.includes}/include</argument>
+                                        <argument>-I${java.includes}/include/linux</argument>
+                                        <argument>-I/usr/lib64/</argument>
+                                        <argument>-I/usr/include/criu</argument>
+                                        <argument>-I${project.build.directory}/native/javah</argument>
+                                        <argument>-Lcriu</argument>
+                                        <argument>-o${project.build.outputDirectory}/libJigawatts_aarch64.so</argument>
+                                        <argument>${project.basedir}/src/main/cpp/com_redhat_jigawatts_Jigawatts.cpp
+                                        </argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>cross-compile-cpp-ppc64le</id>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <phase>process-classes</phase>
+                                <configuration>
+                                    <!-- may not work under root!-->
+                                    <executable>ppc64le-linux-gnu-gcc
+                                    </executable><!-- dnf install gcc-c++-ppc64le-linux-gnu gcc-ppc64le-linux-gnu -->
+                                    <arguments>
+                                        <argument>-v</argument>
+                                        <argument>-shared</argument>
+                                        <!--<argument>-static</argument> ???? can criu be static ????-->
+                                        <!-- mock  -r fedora-35-ppc64le -install glibc-devel glibc-static criu-devel -->
+                                        <argument>--sysroot=/var/lib/mock/fedora-35-ppc64le/root/</argument>
+                                        <argument>-fPIC</argument>
+                                        <argument>-I${java.includes}/include</argument>
+                                        <argument>-I${java.includes}/include/linux</argument>
+                                        <argument>-I/usr/lib64/</argument>
+                                        <argument>-I/usr/include/criu</argument>
+                                        <argument>-I${project.build.directory}/native/javah</argument>
+                                        <argument>-Lcriu</argument>
+                                        <argument>-o${project.build.outputDirectory}/libJigawatts_ppc64le.so</argument>
+                                        <argument>${project.basedir}/src/main/cpp/com_redhat_jigawatts_Jigawatts.cpp
+                                        </argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <!-- this may sound like nonsense, but the goal is to build against same os as ppc and aarch-->
+                                <id>cross-compile-cpp-x86_64</id>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <phase>process-classes</phase>
+                                <configuration>
+                                    <!-- may not work under root!-->
+                                    <executable>gcc</executable><!-- dnf install gcc-c++ gcc -->
+                                    <arguments>
+                                        <argument>-v</argument>
+                                        <argument>-shared</argument>
+                                        <!--<argument>-static</argument> ???? can criu be static ????-->
+                                        <!-- mock  -r fedora-35-x86_64 -install glibc-devel glibc-static criu-devel -->
+                                        <argument>--sysroot=/var/lib/mock/fedora-35-x86_64/root/</argument>
+                                        <argument>-fPIC</argument>
+                                        <argument>-I${java.includes}/include</argument>
+                                        <argument>-I${java.includes}/include/linux</argument>
+                                        <argument>-I/usr/lib64/</argument>
+                                        <argument>-I/usr/include/criu</argument>
+                                        <argument>-I${project.build.directory}/native/javah</argument>
+                                        <argument>-Lcriu</argument>
+                                        <argument>-o${project.build.outputDirectory}/libJigawatts_x86_64.so</argument>
+                                        <argument>${project.basedir}/src/main/cpp/com_redhat_jigawatts_Jigawatts.cpp
+                                        </argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>java</id>
             <activation>
                 <activeByDefault>true</activeByDefault>

--- a/src/main/java/com/redhat/jigawatts/LibraryLoader.java
+++ b/src/main/java/com/redhat/jigawatts/LibraryLoader.java
@@ -13,7 +13,31 @@ import java.util.Date;
 
 class LibraryLoader {
 
+    private static String getInternalArchedLibrarySuffix() {
+        if (getPropertyOrVar(LIBRARY_ARCH_PROP, false) != null) {
+            return getPropertyOrVar(LIBRARY_ARCH_PROP, false);
+        }
+        final String suffixDelimiter = "_"; //intentionally here, so LIBRARY_ARCH_PROP can get rid of it
+        if (System.getProperty("os.arch").equals("amd64")) {
+            return suffixDelimiter + "x86_64";
+        } else if (System.getProperty("os.arch").equals("aarch64") || System.getProperty("os.arch").startsWith("arm")) {
+            return suffixDelimiter + "aarch64";
+        } else if (System.getProperty("os.arch").equals("ppc64le") || System.getProperty("os.arch").startsWith("ppc64")) {
+            return suffixDelimiter + "aarch64";
+        } else {
+            return null;
+        }
+    }
+
+    private static URL getInternalArchedLibrary() {
+        String libraryName = System.mapLibraryName("Jigawatts" + getInternalArchedLibrarySuffix());
+        return Jigawatts.class.getClassLoader().getResource(libraryName);
+    }
+
     private static URL getInternalLibrary() {
+        if (getInternalArchedLibrary() != null) {
+            return getInternalArchedLibrary();
+        }
         String libraryName = System.mapLibraryName("Jigawatts");
         return Jigawatts.class.getClassLoader().getResource(libraryName);
     }
@@ -46,7 +70,7 @@ class LibraryLoader {
                         logPath.toFile().createNewFile();
                     }
                     Files.write(logPath, ("[" + new Date().toString() + "] " + s + "\n").getBytes(), StandardOpenOption.APPEND);
-                } catch (Exception ex){
+                } catch (Exception ex) {
                     ex.printStackTrace();
                 }
             }
@@ -54,22 +78,29 @@ class LibraryLoader {
     }
 
     private static String getPropertyOrVar(String s) {
+        return getPropertyOrVar(s, true);
+    }
+
+    private static String getPropertyOrVar(String s, boolean trimToNull) {
         String prop = System.getProperty(s);
         if (prop != null) {
-            return trimToNull(prop);
+            return trimToNull(prop, trimToNull);
         }
-        return trimToNull(System.getenv(propertyToVar(s)));
+        return trimToNull(System.getenv(propertyToVar(s)), trimToNull);
     }
 
     static String propertyToVar(String s) {
         return s.toUpperCase().replace(".", "_");
     }
 
-    static String trimToNull(String s) {
+    static String trimToNull(String s, boolean reallyTrim) {
         if (s == null) {
             return null;
         }
         s = s.trim();
+        if (!reallyTrim) {
+            return s;
+        }
         if (s.isEmpty()) {
             return null;
         }
@@ -126,6 +157,7 @@ class LibraryLoader {
         throw new RuntimeException(lib + " library not found on java.library.path/LD_LIBRARY_PATH!");
     }
 
+    private static final String LIBRARY_ARCH_PROP = "jigawatts.library.arch";
     private static final String LIBRARY_TARGETFILE_PROP = "jigawatts.library.targetfile";
     private static final String LIBRARY_EXTERNAL_PROP = "jigawatts.library";
     private static final String VERBOSE_PROP = "jigawatts.verbose";
@@ -163,6 +195,8 @@ class LibraryLoader {
         System.out.println("Native library loaded!");
         System.out.println("If jigawatts is packed with embedded dynamic library, it is used in advance. If it is missing, the system library is searched for.");
         System.out.println("To change the loading of native bits you can use following properties/variables. Property is used with priority.");
+        System.out.println(" * In release jar, native library for ppc64le, aarch64 and x86_64 is packed, and used with priority. You can chnage the detected arch by:");
+        System.out.println("    " + PROP + LIBRARY_ARCH_PROP + "/" + VAR + propertyToVar(LIBRARY_ARCH_PROP) + " (ignored if not existing, now " + System.getProperty("os.arch") + ")");
         System.out.println(" * The internal library will be unpacked and loaded from given file. If given file exists, it is not overwritten");
         System.out.println("    " + PROP + LIBRARY_TARGETFILE_PROP + "/" + VAR + propertyToVar(LIBRARY_TARGETFILE_PROP) + ": " + getInternalLibraryExtractedFile());
         System.out.println(" * The internal library will not be used, given file will be used");

--- a/src/test/java/com/redhat/jigawatts/LibraryLoaderTest.java
+++ b/src/test/java/com/redhat/jigawatts/LibraryLoaderTest.java
@@ -6,11 +6,18 @@ import org.junit.jupiter.api.Test;
 public class LibraryLoaderTest {
 
     @Test
-    public void testTrimToNull(){
-        Assertions.assertNull(LibraryLoader.trimToNull(null));
-        Assertions.assertNull(LibraryLoader.trimToNull(""));
-        Assertions.assertNull(LibraryLoader.trimToNull("    "));
-        Assertions.assertEquals("hi!", LibraryLoader.trimToNull("  hi!  "));
+    public void testTrimToNull() {
+        Assertions.assertNull(LibraryLoader.trimToNull(null, true));
+        Assertions.assertNull(LibraryLoader.trimToNull("", true));
+        Assertions.assertNull(LibraryLoader.trimToNull("    ", true));
+        Assertions.assertEquals("hi!", LibraryLoader.trimToNull("  hi!  ", true));
+    }
+
+    public void testTrimToWithouNUll() {
+        Assertions.assertNull(LibraryLoader.trimToNull(null, false));
+        Assertions.assertEquals("", LibraryLoader.trimToNull("", false));
+        Assertions.assertEquals("", LibraryLoader.trimToNull("    ", false));
+        Assertions.assertEquals("hi!", LibraryLoader.trimToNull("  hi!  ", false));
     }
 
     @Test


### PR DESCRIPTION
This pr is possible way to proper upstream binary release.
It is capable to create jar, which contains several crosscompiled .so files (aarch64, ppc64le and x86_64).

Originally I first wanted to implement https://github.com/chflood/jigawatts/issues/25 But I found that current autotools is unable of proper compilation and to fix it overcommed my autotools expertise (https://github.com/chflood/jigawatts/issues/26) and @gnu-andrew  will need to help.

The first two commits "Reformated pom.xml to acomodate profile indentation" and "Separated native and java profiles in pom.xml" can go in, they can do no harm, and are necessary to fix https://github.com/chflood/jigawatts/issues/25

The last - the crosscompilation itself -commit is buggy as it is - See commented out "-static" from gcc call, so it obviously fail to run later. I had failed to crosscompile and even compile agaisnt criulib staticaally. @chflood  does it evenhave sense? Is it possible in current criu setup? is it possibl eat all?