### PR TITLE
Small test fixes

### DIFF
--- a/src/test/java/com/redhat/jigawatts/RandomTest.java
+++ b/src/test/java/com/redhat/jigawatts/RandomTest.java
@@ -104,7 +104,7 @@ public class RandomTest {
 	    System.out.println("output line " + i++ + " = " + l);
 	}
 	i = 0;
-	while ((l = output.readLine()) != null) {
+	while ((l = error.readLine()) != null) {
 	    System.out.println("error line " + i++ + " = " + l);
 	}
 	

--- a/src/test/java/com/redhat/jigawatts/TestHooks.java
+++ b/src/test/java/com/redhat/jigawatts/TestHooks.java
@@ -78,7 +78,7 @@ public class TestHooks {
 	    System.out.println("output line " + i++ + " = " + l);
 	}
 	i = 0;
-	while ((l = output.readLine()) != null) {
+	while ((l = error.readLine()) != null) {
 	    System.out.println("error line " + i++ + " = " + l);
 	}
 	

--- a/src/test/java/com/redhat/jigawatts/TestHooks.java
+++ b/src/test/java/com/redhat/jigawatts/TestHooks.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.util.Arrays;
 
 class Node {
     Node left;
@@ -162,6 +163,9 @@ public class TestHooks {
 	Path tmpDir = Paths.get("src","test","resources","jigawatts", "testhooks", "without");
 	Node[] trees = generateALotOfGarbage(5000, 1000, 100000);
 	// we want trees alive right up until the call to savetheworld	
+	if (Arrays.hashCode(trees) == System.nanoTime()) {
+		System.out.println(" ");
+	}
 	Jigawatts.saveTheWorld(tmpDir.toString());
     }
 
@@ -169,6 +173,10 @@ public class TestHooks {
 	Jigawatts.registerCheckpointHook(new TestHooksBeforeHook("Test Hooks Before Hook"));
 	Path tmpDir = Paths.get("src","test","resources","jigawatts", "testhooks", "with");
 	Node[] trees = generateALotOfGarbage(5000, 1000, 100000);
+	// Use trees to avoid being dead code eliminated
+	if (Arrays.hashCode(trees) == System.nanoTime()) {
+		System.out.println(" ");
+	}
 	Jigawatts.saveTheWorld(tmpDir.toString());
     }
 

--- a/src/test/java/com/redhat/jigawatts/TestStopRunning.java
+++ b/src/test/java/com/redhat/jigawatts/TestStopRunning.java
@@ -42,7 +42,7 @@ public class TestStopRunning {
 	    System.out.println("output line " + i++ + " = " + l);
 	}
 	i = 0;
-	while ((l = output.readLine()) != null) {
+	while ((l = error.readLine()) != null) {
 	    System.out.println("error line " + i++ + " = " + l);
 	}
 	
@@ -63,7 +63,7 @@ public class TestStopRunning {
 	    System.out.println("output line " + i++ + " = " + l);
 	}
 	i = 0;
-	while ((l = output.readLine()) != null) {
+	while ((l = error.readLine()) != null) {
 	    System.out.println("error line " + i++ + " = " + l);
 	}
 	


### PR DESCRIPTION
Contains a couple of fixes:

First it fixes process builder output in tests to show errors, otherwise reasons for test failures are not shown.

Second, I'm seeing some random failures like:
```
Process Process[pid=5119, exitValue=0] has leading size 12
Process Process[pid=5118, exitValue=0] has leading size 12
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 14.029 s <<< FAILURE! - in TestHooks
[ERROR] TestHooks.TestOne(Path)  Time elapsed: 14.028 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <true> but was: <false>
	at TestHooks.TestOne(TestHooks.java:118)
```

The `trees` value is not used, so it could be dead code eliminated. Using the value seems to be enough to avoid DCE and get the GC logic working as the test expects. It might not be failproof but seems to work for now. On my server this was failing every other run.